### PR TITLE
Use path in node_modules to run tsc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 .PHONY: compile
 compile:
 	rm -rf ./dist/
-	tsc -p tsconfig.json
+	./node_modules/typescript/bin/tsc -p tsconfig.json
 	cp -a src/proto_idl_codegen dist/
 .PHONY: tslnt
 tslint:


### PR DESCRIPTION
The `Makefile` used to assume that `tsc` was on the current path which is not
always true. This change modifies the `Makefile` to use the `tsc` script under
the `node_modules` folder.