### PR TITLE
feat: add tracer config types

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -19,9 +19,10 @@ import RemoteDispatcher from './dispatchers/remote';
 import {Dispatcher} from './dispatchers/dispatcher';
 import InMemoryDispatcher from './dispatchers/in_memory';
 import NoopDispatcher from './dispatchers/noop';
+import { TracerConfig } from './tracer-config';
 
 export default class Configuration {
-    static _getDispatcher(config): Dispatcher {
+    static _getDispatcher(config: TracerConfig): Dispatcher {
 
         const dispatcher = config.dispatcher;
         if (dispatcher) {

--- a/src/dispatchers/remote.ts
+++ b/src/dispatchers/remote.ts
@@ -18,14 +18,14 @@ import * as grpc from 'grpc';
 const services  = require('../proto_idl_codegen/agent/spanAgent_grpc_pb');
 import {Dispatcher} from './dispatcher';
 import Span from '../span';
-import NullLogger from '../logger';
+import { Logger, NullLogger } from '../logger';
 import Utils from '../utils';
 
 export default class RemoteDispatcher implements Dispatcher {
     _client: any;
     _logger: any;
 
-    constructor(agentHost: string, agentPort: number, logger = new NullLogger()) {
+    constructor(agentHost: string, agentPort: number, logger: Logger = new NullLogger()) {
         agentHost = agentHost || 'haystack-agent';
         agentPort = agentPort || 35000;
         logger.info(`Initializing the remote dispatcher, connecting at ${agentHost}:${agentPort}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,11 +23,14 @@ import InMemoryDispatcher from './dispatchers/in_memory';
 import FileDispatcher from './dispatchers/file';
 import AgentDispatcher from './dispatchers/remote';
 import Configuration from './configuration';
+import { Logger } from './logger';
+import { TracerConfig } from './tracer-config';
 
 import * as opentracing from 'opentracing';
 
 export {
     Configuration,
+    TracerConfig,
     Tracer,
     SpanContext,
     Span,
@@ -35,7 +38,8 @@ export {
     InMemoryDispatcher,
     FileDispatcher,
     AgentDispatcher,
-    opentracing
+    opentracing,
+    Logger
 };
 
 module.exports = {

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -14,9 +14,5 @@
  *       limitations under the License.
  */
 
-export default class NullLogger {
-    debug(msg: string): void {}
-    info(msg: string): void {}
-    warn(msg: string): void {}
-    error(msg: string): void {}
-}
+export * from './null-logger';
+export * from './logger';

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -1,0 +1,22 @@
+/*
+ *  Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ */
+
+export interface Logger {
+    debug(msg: string): void;
+    info(msg: string): void;
+    warn(msg: string): void;
+    error(msg: string): void;
+}

--- a/src/logger/null-logger.ts
+++ b/src/logger/null-logger.ts
@@ -1,0 +1,24 @@
+/*
+ *  Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ */
+
+import { Logger } from './logger';
+
+export class NullLogger implements Logger {
+    debug(msg: string): void {}
+    info(msg: string): void {}
+    warn(msg: string): void {}
+    error(msg: string): void {}
+}

--- a/src/tracer-config.ts
+++ b/src/tracer-config.ts
@@ -1,0 +1,25 @@
+/*
+ *  Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ */
+
+import { Logger } from './logger/index';
+
+export interface TracerConfig {
+    disable?: boolean;
+    serviceName: string;
+    logger?: Logger;
+    commonTags?: any;
+    dispatcher?: any;
+}

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -21,13 +21,14 @@ import {Dispatcher} from './dispatchers/dispatcher';
 import Span from './span';
 import SpanContext from './span_context';
 import NoopDispatcher from './dispatchers/noop';
-import NullLogger from './logger';
+import { Logger, NullLogger } from './logger/index';
 import Utils from './utils';
 import PropagationRegistry from './propagators/propagation_registry';
 import TextMapPropagator from './propagators/textmap_propagator';
 import URLCodex from './propagators/url_codex';
 import StartSpanFields from './start_span_fields';
 import BinaryPropagator from './propagators/binary_propagator';
+import { TracerConfig } from './tracer-config';
 
 export default class Tracer extends opentracing.Tracer {
     _serviceName: string;
@@ -39,7 +40,7 @@ export default class Tracer extends opentracing.Tracer {
     constructor(serviceName: string,
                 dispatcher = new NoopDispatcher(),
                 commonTags: any = {},
-                logger = new NullLogger()) {
+                logger: Logger = new NullLogger()) {
         super();
         this._commonTags = commonTags || {};
         this._serviceName = serviceName;
@@ -163,7 +164,7 @@ export default class Tracer extends opentracing.Tracer {
         return propagator.extract(carrier);
     }
 
-    static initTracer(config): opentracing.Tracer {
+    static initTracer(config: TracerConfig): opentracing.Tracer {
         if (config.disable) {
             return new opentracing.Tracer();
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,7 @@
 
 import * as uuid from 'uuid';
 import Span from './span';
+
 const messages  = require('./proto_idl_codegen/span_pb');
 
 export default class Utils {


### PR DESCRIPTION
Expose the config types so that clients can easily understand what is required without looking at the source code.