### PR TITLE
making propagation keys case insensitive

### DIFF
--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
    haystack_agent:
-    image: expediadotcom/haystack-agent:0.1
+    image: expediadotcom/haystack-agent:0.1.3
     depends_on:
     - zookeeper
     - kafkasvc

--- a/src/propagators/textmap_propagator.ts
+++ b/src/propagators/textmap_propagator.ts
@@ -42,12 +42,25 @@ export default class TextMapPropagator implements Propagator {
 
     extract(carrier: any): SpanContext {
         const baggage = {};
+        let traceId = '';
+        let spanId = '';
+        let parentSpanId = '';
+
         for (const key in carrier) {
-            if (carrier.hasOwnProperty(key) && key.indexOf(this._opts.baggageKeyPrefix()) === 0) {
-                const keySansPrefix = key.substring(this._opts.baggageKeyPrefix().length);
-                baggage[keySansPrefix] = this._codex.decode(carrier[key]);
-            }
+            if (carrier.hasOwnProperty(key)) {
+                 const lcKey = key.toLowerCase();
+                 if (lcKey.indexOf(this._opts.baggageKeyPrefix().toLowerCase()) === 0) {
+                 const keySansPrefix = key.substring(this._opts.baggageKeyPrefix().length);
+                 baggage[keySansPrefix] = this._codex.decode(carrier[key]);
+              } else if (lcKey === this._opts.traceIdKey().toLowerCase()) {
+                 traceId = carrier[key];
+              } else if (lcKey === this._opts.spanIdKey().toLowerCase()) {
+                 spanId = carrier[key];
+              } else if (lcKey === this._opts.parentSpanIdKey().toLowerCase()) {
+                 parentSpanId = carrier[key];
+              }
+           }
         }
-        return new SpanContext(carrier[this._opts.traceIdKey()], carrier[this._opts.spanIdKey()], carrier[this._opts.parentSpanIdKey()], baggage);
+        return new SpanContext(traceId, spanId, parentSpanId, baggage);
     }
 }

--- a/tests/unit/tracer.spec.ts
+++ b/tests/unit/tracer.spec.ts
@@ -131,7 +131,8 @@ describe('Tracer tests', () => {
             const tracer = new Tracer(dummyServiceName, inMemSpanStore, commonTags);
 
             const startServerSpanFields = new StartSpanFields();
-            const carrier = {'Trace-ID': 'T1' , 'Span-ID': 'S1', 'Parent-ID': 'P1', 'Baggage-myKey': 'myVal'};
+            console.log('starting .....');
+            const carrier = {'Trace-ID': 'T1' , 'Span-ID': 'S1', 'parent-id': 'P1', 'Baggage-myKey': 'myVal', 'baggage-mylowercasekey': 'myval'};
             const clientSpanContext = tracer.extract(opentracing.FORMAT_TEXT_MAP, carrier);
             startServerSpanFields.childOf = clientSpanContext;
             const serverSpan = tracer.startSpan(dummyOperation, startServerSpanFields);
@@ -140,10 +141,12 @@ describe('Tracer tests', () => {
             
             serverSpan.finish();
             expect(inMemSpanStore.spans().length).equal(1);
-            const receviedSpan = inMemSpanStore.spans()[0];
-            expect(receviedSpan.context().traceId).eq('T1');
-            expect(receviedSpan.context().spanId === 'S1').eq(true);
-            expect(receviedSpan.context().parentSpanId).eq('P1');
+            const receivedSpan = inMemSpanStore.spans()[0];
+            expect(receivedSpan.context().traceId).eq('T1');
+            expect(receivedSpan.context().spanId === 'S1').eq(true);
+            expect(receivedSpan.context().parentSpanId).eq('P1');
+            expect(receivedSpan.context().baggage['myKey']).eq('myVal');
+            expect(receivedSpan.context().baggage['mylowercasekey']).eq('myval');
         });
 
         it('should create server span as a non-sharable span if tracer is in dualspan mode and context is extracted', () => {


### PR DESCRIPTION
HTTP RFC : https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2

```
HTTP header fields, which include general-header (section 4.5), request-header (section 5.3), 
response-header (section 6.2), and entity-header (section 7.1) fields, follow the same generic format 
as that given in Section 3.1 of RFC 822 [9]. Each header field consists of a name followed by a colon
(":") and the field value. *Field names are case-insensitive.*
```

When SpanContext is extracted using `TextMapPropagator`, keys in the carrier can be of different case. In many cases, carrier is `HttpHeadersCarrier` which exposes HTTP headers read from transport. According to RFC, these header names are case insensitive.  Some of the servers and clients do not maintain case of the header provided/read. 