### PR TITLE
Update gRPC and Protobuf versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "Haystack <haystack@expedia.com>"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "^1.0.3",
-    "google-protobuf": "^3.0.0",
+    "@grpc/grpc-js": "^1.1.5",
+    "google-protobuf": "^3.13.0",
     "opentracing": "^0.14.0",
     "request": "^2.88.0",
     "uuid": "^3.2.1"


### PR DESCRIPTION
A [bug](https://github.com/grpc/grpc-node/issues/1475) found in in grpc-node (with affect on grpc-js) caused the routing with some service meshes impossible.